### PR TITLE
Add helper to load plugin entry points

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -728,6 +728,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "types-setuptools"
+version = "65.6.0.2"
+description = "Typing stubs for setuptools"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -781,7 +789,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "dacc3bd723d5c91befa82e376e9a210e05a9a608ebfb4d5305658c351be055b0"
+content-hash = "13f4ad6e55d45e8752c245e85ca71a9c1c3fa07020e0aba57c8c76ba46eca66a"
 
 [metadata.files]
 alabaster = [
@@ -1290,6 +1298,10 @@ typed-ast = [
     {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
     {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
+]
+types-setuptools = [
+    {file = "types-setuptools-65.6.0.2.tar.gz", hash = "sha256:ad60ccf01d626de9762224448f36c13e0660e863afd6dc11d979b3739a6c7d24"},
+    {file = "types_setuptools-65.6.0.2-py3-none-any.whl", hash = "sha256:2c2b4f756f79778074ce2d21f745aa737b12160d9f8dfa274f47a7287c7a2fee"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ pre-commit = "^2.17.0"
 black = "22.3.0"
 mypy = "^0.931"
 mypy-extensions = "^0.4.3"
+types-setuptools = "^65.6.0.2"
 
 Sphinx = "^5.0"
 sphinx-copybutton = "^0.4"

--- a/src/ansys/utilities/local_instancemanager_server/__init__.py
+++ b/src/ansys/utilities/local_instancemanager_server/__init__.py
@@ -9,8 +9,12 @@ try:
 except ModuleNotFoundError:
     import importlib_metadata  # type: ignore
 
-from . import helpers, interface
+from . import helpers, interface, plugins
 
 __version__ = importlib_metadata.version(__name__.replace(".", "-"))
 
-__all__ = ["interface", "helpers"]
+__all__ = [
+    "interface",
+    "helpers",
+    "plugins",
+]

--- a/src/ansys/utilities/local_instancemanager_server/plugins.py
+++ b/src/ansys/utilities/local_instancemanager_server/plugins.py
@@ -1,0 +1,15 @@
+from typing import Tuple
+
+try:
+    import importlib.metadata as importlib_metadata  # type: ignore
+except ModuleNotFoundError:
+    import importlib_metadata  # type: ignore
+
+LAUNCHER_ENTRY_POINT = "local_pim_server.launcher"
+
+
+def get_entry_points() -> Tuple[importlib_metadata.EntryPoint, ...]:
+    try:
+        return importlib_metadata.entry_points()[LAUNCHER_ENTRY_POINT]  # type: ignore
+    except KeyError:
+        return tuple()


### PR DESCRIPTION
Define `LAUNCHER_ENTRY_POINT` constant to define the entry point group, and
a helper method `get_entry_points` to get the plugins.