### PR TITLE
Enable multi-URL servers

### DIFF
--- a/src/ansys/utilities/local_instancemanager_server/interface.py
+++ b/src/ansys/utilities/local_instancemanager_server/interface.py
@@ -1,7 +1,7 @@
 """Interface definitions for implementing a local product launcher."""
 
 from enum import Enum, auto
-from typing import Type, TypeVar
+from typing import Dict, Type, TypeVar
 
 try:
     from typing import Protocol
@@ -30,7 +30,7 @@ class LauncherProtocol(Protocol[LAUNCHER_CONFIG_T]):
     """
 
     CONFIG_MODEL: Type[LAUNCHER_CONFIG_T]
-    SERVER_TYPE: ServerType
+    SERVER_SPEC: Dict[str, ServerType]
 
     def __init__(self, *, config: LAUNCHER_CONFIG_T):
         """Launch a local product instance with the given configuration."""
@@ -42,5 +42,5 @@ class LauncherProtocol(Protocol[LAUNCHER_CONFIG_T]):
         """Check if the product instance is responding to requests."""
 
     @property
-    def url(self) -> str:
-        """Provide the on which the server is listening."""
+    def urls(self) -> Dict[str, str]:
+        """Provide the URLs on which the server is listening."""

--- a/src/ansys/utilities/local_instancemanager_server/launch.py
+++ b/src/ansys/utilities/local_instancemanager_server/launch.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import Optional, Type, cast
 
 from .config import CONFIG_HANDLER, CONFIGS_KEY, LAUNCH_MODE_KEY
-from .interface import LAUNCHER_CONFIG_T, LauncherProtocol, ServerType
+from .interface import LAUNCHER_CONFIG_T, LauncherProtocol
 from .plugins import get_launcher
-from .server_handle import GrpcServerHandle, ServerHandle
+from .server_handle import ServerHandle
 
 
 def launch_product(
@@ -52,8 +52,4 @@ def launch_product(
                 f"Incompatible config of type '{type(config)} supplied, "
                 f"needs '{launcher_klass.CONFIG_MODEL}'."
             )
-    if launcher_klass.SERVER_TYPE is ServerType.GRPC:
-        server_klass: Type[ServerHandle] = GrpcServerHandle
-    else:
-        server_klass = ServerHandle
-    return server_klass(launcher=launcher_klass(config=config))
+    return ServerHandle(launcher=launcher_klass(config=config))


### PR DESCRIPTION
Fixes #7 

Change the interface s.t. multiple URLs can be exposed by launching a single product.

The `url` and `channel` properties are renamed (add plural s), and return a dict instead of
a single value.
The dict keys and server type for each URL are specified in the `SERVER_SPEC` class attribute
of the launcher.

The `channels` property is moved to the main `ServerHandle`, since a product could launch
mixed (generic + grpc) servers. It will contain values only for the URLs on which a grpc server
is running.