### PR TITLE
Add flag to control overwriting launch_mode

### DIFF
--- a/src/ansys/tools/local_product_launcher/config.py
+++ b/src/ansys/tools/local_product_launcher/config.py
@@ -47,11 +47,26 @@ def get_config_for(*, product_name: str, launch_mode: Optional[str]) -> LAUNCHER
     return config_class(**get_config()[product_name].configs[launch_mode].dict())
 
 
-def set_config(*, product_name: str, launch_mode: str, config: LAUNCHER_CONFIG_T) -> None:
+def is_configured(*, product_name: str, launch_mode: Optional[str] = None) -> bool:
+    try:
+        get_config_for(product_name=product_name, launch_mode=launch_mode)
+        return True
+    except KeyError:
+        return False
+
+
+def set_config(
+    *,
+    product_name: str,
+    launch_mode: str,
+    config: LAUNCHER_CONFIG_T,
+    overwrite_default: bool = False,
+) -> None:
     try:
         product_config = get_config()[product_name]
-        product_config.launch_mode = launch_mode
         product_config.configs[launch_mode] = config
+        if overwrite_default:
+            product_config.launch_mode = launch_mode
     except KeyError:
         get_config()[product_name] = ProductConfig(
             launch_mode=launch_mode, configs={launch_mode: config}

--- a/tests/test_cli/test_multiple_plugins.py
+++ b/tests/test_cli/test_multiple_plugins.py
@@ -104,6 +104,33 @@ def test_configure_two_product_launchers(temp_config_file):
                 TEST_LAUNCH_MODE_A1: {"field_a1": 1},
                 TEST_LAUNCH_MODE_A2: {"field_a2": 2},
             },
+            "launch_mode": TEST_LAUNCH_MODE_A1,
+        }
+    }
+    check_result_config(temp_config_file, expected_config)
+
+
+def test_configure_two_product_launchers_overwrite(temp_config_file):
+    cli_command = cli.build_cli(PLUGINS)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_command,
+        ["configure", TEST_PRODUCT_A, TEST_LAUNCH_MODE_A1, "--field_a1=1"],
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        cli_command,
+        ["configure", TEST_PRODUCT_A, TEST_LAUNCH_MODE_A2, "--field_a2=2", "--overwrite_default"],
+    )
+    assert result.exit_code == 0
+
+    expected_config = {
+        TEST_PRODUCT_A: {
+            "configs": {
+                TEST_LAUNCH_MODE_A1: {"field_a1": 1},
+                TEST_LAUNCH_MODE_A2: {"field_a2": 2},
+            },
             "launch_mode": TEST_LAUNCH_MODE_A2,
         }
     }

--- a/tests/test_cli/test_single_plugin.py
+++ b/tests/test_cli/test_single_plugin.py
@@ -52,8 +52,12 @@ def test_cli_mock_plugin(mock_plugins):
     assert TEST_LAUNCH_MODE in product_group.commands
 
     launcher_command = product_group.commands[TEST_LAUNCH_MODE]
-    assert len(launcher_command.params) == 2
-    assert [p.name for p in launcher_command.params] == ["int_field", "str_field"]
+    assert len(launcher_command.params) == 3
+    assert [p.name for p in launcher_command.params] == [
+        "int_field",
+        "str_field",
+        "overwrite_default",
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add a flag `overwrite_default` that controls whether the `launch_mode` should 
be overwritten.

Note that this makes `overwrite_default` a special name, which is not allowed in
launcher configurations.

Alternatively, the `--overwrite_default` flag could be accepted at the group level:
```bash
ansys-launcher configure ACP --overwrite_default direct <...>
```
instead of 
```bash
ansys-launcher configure ACP direct --overwrite_default <...>
```
The drawback of that approach is that it complicates the logic for whether the
user should be prompted (currently determined by whether it actually makes
a difference that the flag is set).