### PR TITLE
Replace pydantic by dataclasses

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -63,9 +63,7 @@ nitpick_ignore = [
     )  # TypeVar, not a class
 ]
 
-nitpick_ignore_regex = [
-    (".*", "pydantic\..*"),
-]
+nitpick_ignore_regex = []
 
 # autodoc options
 autoclass_content = "class"

--- a/doc/styles/Vocab/CustomVocab/accept.txt
+++ b/doc/styles/Vocab/CustomVocab/accept.txt
@@ -1,3 +1,2 @@
 mypy
-pydantic
 xkcd

--- a/poetry.lock
+++ b/poetry.lock
@@ -411,21 +411,6 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
-name = "pydantic"
-version = "1.10.2"
-description = "Data validation and settings management using python type hints"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-typing-extensions = ">=4.1.0"
-
-[package.extras]
-dotenv = ["python-dotenv (>=0.10.4)"]
-email = ["email-validator (>=1.0.3)"]
-
-[[package]]
 name = "pydata-sphinx-theme"
 version = "0.9.0"
 description = "Bootstrap-based Sphinx theme from the PyData community"
@@ -816,7 +801,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "5ff96ef563f0c2c0ff71f530c7d99b7c2c1f3c5ad21c54f5ca464f73d8df849e"
+content-hash = "90a93881e439dd148df42bb8cd3f2a4af78b3a6550e7d3e92b53d9df60c45f07"
 
 [metadata.files]
 alabaster = [
@@ -1142,44 +1127,6 @@ protobuf = [
     {file = "protobuf-4.21.11-py2.py3-none-any.whl", hash = "sha256:4922e3320ed70e81f05060822da36923d09fd9e04e17f411f2d8d8d0070f9f5c"},
     {file = "protobuf-4.21.11-py3-none-any.whl", hash = "sha256:a944dc9550baae276afc7dc8193191d4c2ad660270a1e5ed5a71539817ebe2e2"},
     {file = "protobuf-4.21.11.tar.gz", hash = "sha256:2c6a4d13732d9b094db31b3841986c38b17ac61a3fe05ee26a779d94c4c3fb43"},
-]
-pydantic = [
-    {file = "pydantic-1.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd"},
-    {file = "pydantic-1.10.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a1f5a63a6dfe19d719b1b6e6106561869d2efaca6167f84f5ab9347887d78b98"},
-    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:352aedb1d71b8b0736c6d56ad2bd34c6982720644b0624462059ab29bd6e5912"},
-    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19b3b9ccf97af2b7519c42032441a891a5e05c68368f40865a90eb88833c2559"},
-    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e9069e1b01525a96e6ff49e25876d90d5a563bc31c658289a8772ae186552236"},
-    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:355639d9afc76bcb9b0c3000ddcd08472ae75318a6eb67a15866b87e2efa168c"},
-    {file = "pydantic-1.10.2-cp310-cp310-win_amd64.whl", hash = "sha256:ae544c47bec47a86bc7d350f965d8b15540e27e5aa4f55170ac6a75e5f73b644"},
-    {file = "pydantic-1.10.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4c805731c33a8db4b6ace45ce440c4ef5336e712508b4d9e1aafa617dc9907f"},
-    {file = "pydantic-1.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d49f3db871575e0426b12e2f32fdb25e579dea16486a26e5a0474af87cb1ab0a"},
-    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37c90345ec7dd2f1bcef82ce49b6235b40f282b94d3eec47e801baf864d15525"},
-    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b5ba54d026c2bd2cb769d3468885f23f43710f651688e91f5fb1edcf0ee9283"},
-    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:05e00dbebbe810b33c7a7362f231893183bcc4251f3f2ff991c31d5c08240c42"},
-    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2d0567e60eb01bccda3a4df01df677adf6b437958d35c12a3ac3e0f078b0ee52"},
-    {file = "pydantic-1.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:c6f981882aea41e021f72779ce2a4e87267458cc4d39ea990729e21ef18f0f8c"},
-    {file = "pydantic-1.10.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c4aac8e7103bf598373208f6299fa9a5cfd1fc571f2d40bf1dd1955a63d6eeb5"},
-    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a7b66c3f499108b448f3f004801fcd7d7165fb4200acb03f1c2402da73ce4c"},
-    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bedf309630209e78582ffacda64a21f96f3ed2e51fbf3962d4d488e503420254"},
-    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9300fcbebf85f6339a02c6994b2eb3ff1b9c8c14f502058b5bf349d42447dcf5"},
-    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:216f3bcbf19c726b1cc22b099dd409aa371f55c08800bcea4c44c8f74b73478d"},
-    {file = "pydantic-1.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:dd3f9a40c16daf323cf913593083698caee97df2804aa36c4b3175d5ac1b92a2"},
-    {file = "pydantic-1.10.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b97890e56a694486f772d36efd2ba31612739bc6f3caeee50e9e7e3ebd2fdd13"},
-    {file = "pydantic-1.10.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9cabf4a7f05a776e7793e72793cd92cc865ea0e83a819f9ae4ecccb1b8aa6116"},
-    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06094d18dd5e6f2bbf93efa54991c3240964bb663b87729ac340eb5014310624"},
-    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc78cc83110d2f275ec1970e7a831f4e371ee92405332ebfe9860a715f8336e1"},
-    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ee433e274268a4b0c8fde7ad9d58ecba12b069a033ecc4645bb6303c062d2e9"},
-    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7c2abc4393dea97a4ccbb4ec7d8658d4e22c4765b7b9b9445588f16c71ad9965"},
-    {file = "pydantic-1.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:0b959f4d8211fc964772b595ebb25f7652da3f22322c007b6fed26846a40685e"},
-    {file = "pydantic-1.10.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c33602f93bfb67779f9c507e4d69451664524389546bacfe1bee13cae6dc7488"},
-    {file = "pydantic-1.10.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5760e164b807a48a8f25f8aa1a6d857e6ce62e7ec83ea5d5c5a802eac81bad41"},
-    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6eb843dcc411b6a2237a694f5e1d649fc66c6064d02b204a7e9d194dff81eb4b"},
-    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b8795290deaae348c4eba0cebb196e1c6b98bdbe7f50b2d0d9a4a99716342fe"},
-    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e0bedafe4bc165ad0a56ac0bd7695df25c50f76961da29c050712596cf092d6d"},
-    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2e05aed07fa02231dbf03d0adb1be1d79cabb09025dd45aa094aa8b4e7b9dcda"},
-    {file = "pydantic-1.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:c1ba1afb396148bbc70e9eaa8c06c1716fdddabaf86e7027c5988bae2a829ab6"},
-    {file = "pydantic-1.10.2-py3-none-any.whl", hash = "sha256:1b6ee725bd6e83ec78b1aa32c5b1fa67a3a65badddde3976bca5fe4568f27709"},
-    {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 pydata-sphinx-theme = [
     {file = "pydata_sphinx_theme-0.9.0-py3-none-any.whl", hash = "sha256:b22b442a6d6437e5eaf0a1f057169ffcb31eaa9f10be7d5481a125e735c71c12"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ ansys-launcher = "ansys.tools.local_product_launcher._cli:cli"
 python = ">=3.7,<4.0"
 importlib-metadata = {version = "^4.0", python = "<3.8"}
 typing-extensions = "^4.0"
-pydantic = "^1.10.2"
 click = "^8.1.3"
 grpcio-health-checking = "^1.43"
 grpcio = "^1.51.1"

--- a/src/ansys/tools/local_product_launcher/config.py
+++ b/src/ansys/tools/local_product_launcher/config.py
@@ -7,14 +7,13 @@ Its location can be specified explicitly with the ``ANSYS_LAUNCHER_CONFIG_PATH``
 environment variable.
 """
 
+import dataclasses
 import json
 import os
 import pathlib
 from typing import Any, Dict, Optional, Type, cast
 
 import appdirs
-import pydantic
-import pydantic.generics
 
 from ._plugins import get_config_model
 from .interface import LAUNCHER_CONFIG_T
@@ -31,12 +30,14 @@ __all__ = [
 _CONFIG_PATH_ENV_VAR_NAME = "ANSYS_LAUNCHER_CONFIG_PATH"
 
 
-class _ProductConfig(pydantic.BaseModel):
+@dataclasses.dataclass
+class _ProductConfig:
     launch_mode: str
     configs: Dict[str, Any]
 
 
-class _LauncherConfiguration(pydantic.BaseModel):
+@dataclasses.dataclass
+class _LauncherConfiguration:
     __root__: Dict[str, _ProductConfig]
 
 
@@ -171,7 +172,7 @@ def save_config() -> None:
     if _CONFIG is not None:
         file_path = _get_config_path()
         with open(file_path, "w") as out_f:
-            out_f.write(_CONFIG.json())
+            json.dump(dataclasses.asdict(_CONFIG)["__root__"], out_f)
 
 
 def _get_config() -> Dict[str, _ProductConfig]:

--- a/src/ansys/tools/local_product_launcher/interface.py
+++ b/src/ansys/tools/local_product_launcher/interface.py
@@ -5,18 +5,32 @@ and register it
 """
 
 from enum import Enum, auto
-from typing import Dict, Optional, Type, TypeVar
+from typing import Any, Dict, Optional, Type, TypeVar
 
 try:
     from typing import Protocol
 except ImportError:
     from typing_extensions import Protocol  # type: ignore
 
-import pydantic
+__all__ = [
+    "LAUNCHER_CONFIG_T",
+    "DOC_METADATA_KEY",
+    "DataclassProtocol",
+    "LauncherProtocol",
+    "ServerType",
+]
 
-__all__ = ["LAUNCHER_CONFIG_T", "LauncherProtocol", "ServerType"]
+DOC_METADATA_KEY = "launcher_doc"
+"""Key used in the :py:class:`dataclasses.Field` ``metadata``, for the option description."""
 
-LAUNCHER_CONFIG_T = TypeVar("LAUNCHER_CONFIG_T", bound="pydantic.BaseModel")
+
+class DataclassProtocol(Protocol):
+    """Protocol class for Python dataclasses."""
+
+    __dataclass_fields__: Dict[str, Any]
+
+
+LAUNCHER_CONFIG_T = TypeVar("LAUNCHER_CONFIG_T", bound=DataclassProtocol)
 """Type variable for launcher configuration objects."""
 
 
@@ -67,9 +81,9 @@ class LauncherProtocol(Protocol[LAUNCHER_CONFIG_T]):
     """Defines the configuration options for the launcher.
 
     The configuration options which this launcher accepts, specified
-    as a `pydantic <https://docs.pydantic.dev>`_ Model. Note that the
-    ``default`` and ``description`` of the model fields are used in the
-    configuration CLI, if available.
+    as a :py:func:`dataclass <dataclasses.dataclass>`. Note that the
+    ``default`` and ``metadata[DOC_METADATA_KEY]`` of the fields are
+    used in the configuration CLI, if available.
     """
 
     SERVER_SPEC: Dict[str, ServerType]

--- a/tests/test_cli/common.py
+++ b/tests/test_cli/common.py
@@ -3,5 +3,5 @@ import json
 
 def check_result_config(path, expected):
     with open(path) as f:
-        _config = json.load(f)
-    assert _config == expected
+        config = json.load(f)
+    assert config == expected, f"Unexpected config: {config}"

--- a/tests/test_cli/test_multiple_plugins.py
+++ b/tests/test_cli/test_multiple_plugins.py
@@ -1,5 +1,6 @@
+from dataclasses import dataclass
+
 from click.testing import CliRunner
-import pydantic
 import pytest
 
 from ansys.tools.local_product_launcher import _cli, _plugins, config, interface
@@ -13,7 +14,8 @@ TEST_LAUNCH_MODE_A2 = "LAUNCHER_A2"
 TEST_LAUNCH_MODE_B1 = "LAUNCHER_B1"
 
 
-class MockConfigA1(pydantic.BaseModel):
+@dataclass
+class MockConfigA1:
     field_a1: int
 
 
@@ -21,7 +23,8 @@ class MockLauncherA1(interface.LauncherProtocol[MockConfigA1]):
     CONFIG_MODEL = MockConfigA1
 
 
-class MockConfigA2(pydantic.BaseModel):
+@dataclass
+class MockConfigA2:
     field_a2: int
 
 
@@ -29,7 +32,8 @@ class MockLauncherA2(interface.LauncherProtocol[MockConfigA2]):
     CONFIG_MODEL = MockConfigA2
 
 
-class MockConfigB1(pydantic.BaseModel):
+@dataclass
+class MockConfigB1:
     field_b1: int
 
 

--- a/tests/test_cli/test_single_plugin.py
+++ b/tests/test_cli/test_single_plugin.py
@@ -1,7 +1,7 @@
+from dataclasses import dataclass
 from typing import Dict
 
 from click.testing import CliRunner
-import pydantic
 import pytest
 
 from ansys.tools.local_product_launcher import _cli, interface
@@ -9,7 +9,8 @@ from ansys.tools.local_product_launcher import _cli, interface
 from .common import check_result_config
 
 
-class MockConfig(pydantic.BaseModel):
+@dataclass
+class MockConfig:
     int_field: int
     str_field: str
     json_field: Dict[str, str]

--- a/tests/test_integration/simple_test_launcher.py
+++ b/tests/test_integration/simple_test_launcher.py
@@ -1,22 +1,28 @@
+import dataclasses
 import pathlib
 import subprocess
 import sys
 from typing import Optional
 
 import grpc
-import pydantic
 
 from ansys.tools.local_product_launcher.helpers.grpc import check_grpc_health
 from ansys.tools.local_product_launcher.helpers.ports import find_free_ports
-from ansys.tools.local_product_launcher.interface import LauncherProtocol, ServerType
+from ansys.tools.local_product_launcher.interface import (
+    DOC_METADATA_KEY,
+    LauncherProtocol,
+    ServerType,
+)
 
 SCRIPT_PATH = pathlib.Path(__file__).parent / "simple_test_server.py"
 SERVER_KEY = "main"
 
 
-class SimpleLauncherConfig(pydantic.BaseModel):
-    script_path: str = pydantic.Field(
-        default=str(SCRIPT_PATH), description="Location of the server Python script."
+@dataclasses.dataclass
+class SimpleLauncherConfig:
+    script_path: str = dataclasses.field(
+        default=str(SCRIPT_PATH),
+        metadata={DOC_METADATA_KEY: "Location of the server Python script."},
     )
 
 

--- a/tests/test_integration/test_simple_launcher.py
+++ b/tests/test_integration/test_simple_launcher.py
@@ -1,4 +1,5 @@
-import pydantic
+from dataclasses import dataclass
+
 import pytest
 
 from ansys.tools.local_product_launcher import config, launch_product
@@ -7,6 +8,11 @@ from .simple_test_launcher import SimpleLauncher, SimpleLauncherConfig
 
 PRODUCT_NAME = "TestProduct"
 LAUNCH_MODE = "direct"
+
+
+@dataclass
+class OtherConfig:
+    int_attr: int
 
 
 @pytest.fixture(autouse=True)
@@ -40,7 +46,7 @@ def test_invalid_launch_mode_raises():
 
 def test_invalid_config_raises():
     with pytest.raises(TypeError):
-        launch_product(PRODUCT_NAME, launch_mode=LAUNCH_MODE, config=pydantic.BaseModel())
+        launch_product(PRODUCT_NAME, launch_mode=LAUNCH_MODE, config=OtherConfig(int_attr=3))
 
 
 def test_contextmanager():

--- a/tests/test_plugins/test_plugins.py
+++ b/tests/test_plugins/test_plugins.py
@@ -1,6 +1,7 @@
 """Tests for the 'plugins' module."""
 
-import pydantic
+from dataclasses import dataclass
+
 import pytest
 
 from ansys.tools.local_product_launcher import _plugins, interface
@@ -12,7 +13,8 @@ TEST_LAUNCH_MODE_A2 = "LAUNCHER_A2"
 TEST_LAUNCH_MODE_B1 = "LAUNCHER_B1"
 
 
-class MockConfigA1(pydantic.BaseModel):
+@dataclass
+class MockConfigA1:
     pass
 
 
@@ -20,7 +22,8 @@ class MockLauncherA1(interface.LauncherProtocol[MockConfigA1]):
     CONFIG_MODEL = MockConfigA1
 
 
-class MockConfigA2(pydantic.BaseModel):
+@dataclass
+class MockConfigA2:
     pass
 
 
@@ -28,7 +31,8 @@ class MockLauncherA2(interface.LauncherProtocol[MockConfigA2]):
     CONFIG_MODEL = MockConfigA2
 
 
-class MockConfigB1(pydantic.BaseModel):
+@dataclass
+class MockConfigB1:
     pass
 
 


### PR DESCRIPTION
Replace `pydantic` models by `dataclass`.

The `pydantic` models have a [rather large API](https://docs.pydantic.dev/usage/models/#model-properties), which users will inevitably come
to rely on. To avoid this, we switch to using `dataclass` for the configuration.

The main drawback of using `dataclass` is that there's no standardized way to specify the 
description, which is now passed as a `metadata` value.
Another notable difference is that `dataclass` doesn't do run-time type checking.

