### PR TITLE
Register test helper module for assert rewriting

### DIFF
--- a/tests/test_cli/common.py
+++ b/tests/test_cli/common.py
@@ -4,4 +4,4 @@ import json
 def check_result_config(path, expected):
     with open(path) as f:
         config = json.load(f)
-    assert config == expected, f"Unexpected config: {config}"
+    assert config == expected

--- a/tests/test_cli/conftest.py
+++ b/tests/test_cli/conftest.py
@@ -2,6 +2,8 @@ import pytest
 
 from ansys.tools.local_product_launcher import config
 
+pytest.register_assert_rewrite("test_cli.common")
+
 
 @pytest.fixture
 def temp_config_file(monkeypatch, tmp_path):


### PR DESCRIPTION
Use `pytest.register_assert_rewrite` to improve the error message when the config doesn't match the expected value.