### PR TITLE
Add timeout argument to stop()

### DIFF
--- a/src/ansys/tools/local_product_launcher/interface.py
+++ b/src/ansys/tools/local_product_launcher/interface.py
@@ -121,8 +121,17 @@ class LauncherProtocol(Protocol[LAUNCHER_CONFIG_T]):
     def start(self) -> None:
         """Start the product instance."""
 
-    def stop(self) -> None:
-        """Tear down the product instance."""
+    def stop(self, *, timeout: Optional[float] = None) -> None:
+        """Tear down the product instance.
+
+        Parameters
+        ----------
+        timeout :
+            Time after which the instance can be forcefully stopped.
+            The timeout should be interpreted as a hint to the implementation.
+            It is not _required_ to trigger a force-shutdown, but the stop
+            _must_ return within a finite time.
+        """
 
     def check(self, *, timeout: Optional[float] = None) -> bool:
         """Check if the product instance is responding to requests.
@@ -130,7 +139,7 @@ class LauncherProtocol(Protocol[LAUNCHER_CONFIG_T]):
         Parameters
         ----------
         timeout :
-            Timeout in seconds for the
+            Timeout in seconds for the check.
             The timeout should be interpreted as a hint to the implementation.
             It is not _required_ to return within the given time, but the
             check _must_ return within a finite time (i.e., it must not

--- a/tests/test_integration/simple_test_launcher.py
+++ b/tests/test_integration/simple_test_launcher.py
@@ -49,9 +49,13 @@ class SimpleLauncher(LauncherProtocol[SimpleLauncherConfig]):
             text=True,
         )
 
-    def stop(self):
-        self._process.kill()  # to speed up tests, directly use 'SIGKILL'
-        self._process.wait()
+    def stop(self, *, timeout=None):
+        self._process.terminate()
+        try:
+            self._process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait()
 
     def check(self, *, timeout: Optional[float] = None) -> bool:
         channel = grpc.insecure_channel(self.urls[SERVER_KEY])

--- a/tests/test_integration/test_simple_launcher.py
+++ b/tests/test_integration/test_simple_launcher.py
@@ -37,6 +37,13 @@ def test_explicit_config():
     assert not server.check()
 
 
+def test_stop_with_timeout():
+    server = launch_product(PRODUCT_NAME, launch_mode=LAUNCH_MODE, config=SimpleLauncherConfig())
+    server.wait(timeout=10)
+    server.stop(timeout=1.0)
+    assert not server.check()
+
+
 def test_invalid_launch_mode_raises():
     with pytest.raises(KeyError):
         launch_product(


### PR DESCRIPTION
Fixes #43.

Add a `timeout` argument to the `stop` methods, after which
the product instance is forcefully (instead of gracefully) terminated.