### PR TITLE
Use grouped dependabot updates, switch to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,13 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: "lockfile-only"
+    groups:
+      dependencies:
+        patterns:
+          - "*" # Update all packages together
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
* Use grouped updates for the Python dependencies
* Switch to weekly schedule for both Python and Github Actions dependencies