### PR TITLE
Remove option to create custom product instance subclass

### DIFF
--- a/src/ansys/tools/local_product_launcher/_cli.py
+++ b/src/ansys/tools/local_product_launcher/_cli.py
@@ -28,7 +28,7 @@ from typing import Any, Callable, Optional, cast
 
 import click
 
-from ._plugins import get_all_launcher_plugins
+from ._plugins import get_all_plugins
 from .config import (
     _get_config_path,
     get_config_for,
@@ -261,7 +261,7 @@ def build_cli(plugins: dict[str, dict[str, LauncherProtocol[LAUNCHER_CONFIG_T]]]
 
 # Needs to be defined at the module level, since this is what the [tool.poetry.scripts]
 # entry point refers to.
-cli = build_cli(plugins=get_all_launcher_plugins())
+cli = build_cli(plugins=get_all_plugins())
 
 if __name__ == "__main__":
     cli()

--- a/src/ansys/tools/local_product_launcher/_plugins.py
+++ b/src/ansys/tools/local_product_launcher/_plugins.py
@@ -27,10 +27,8 @@ import importlib.metadata
 from backports.entry_points_selectable import entry_points
 
 from .interface import LAUNCHER_CONFIG_T, LauncherProtocol
-from .product_instance import ProductInstance
 
 LAUNCHER_ENTRY_POINT = "ansys.tools.local_product_launcher.launcher"
-PRODUCT_INSTANCE_CLASS_ENTRY_POINT = "ansys.tools.local_product_launcher.product_instance_class"
 
 
 def get_launcher(
@@ -38,7 +36,7 @@ def get_launcher(
 ) -> type[LauncherProtocol[LAUNCHER_CONFIG_T]]:
     """Get the launcher plugin for a given product and launch mode."""
     ep_name = f"{product_name}.{launch_mode}"
-    for entrypoint in _get_launcher_entry_points():
+    for entrypoint in _get_entry_points():
         if entrypoint.name == ep_name:
             return entrypoint.load()  # type: ignore
     else:
@@ -50,39 +48,19 @@ def get_config_model(*, product_name: str, launch_mode: str) -> type[LAUNCHER_CO
     return get_launcher(product_name=product_name, launch_mode=launch_mode).CONFIG_MODEL
 
 
-def get_all_launcher_plugins() -> dict[str, dict[str, LauncherProtocol[LAUNCHER_CONFIG_T]]]:
+def get_all_plugins() -> dict[str, dict[str, LauncherProtocol[LAUNCHER_CONFIG_T]]]:
     """Get mapping {"<product_name>": {"<launch_mode>": Launcher}} containing all plugins."""
     res: dict[str, dict[str, LauncherProtocol[LAUNCHER_CONFIG_T]]] = dict()
-    for entry_point in _get_launcher_entry_points():
+    for entry_point in _get_entry_points():
         product_name, launch_mode = entry_point.name.split(".")
         res.setdefault(product_name, dict())
         res[product_name][launch_mode] = entry_point.load()
     return res
 
 
-def _get_launcher_entry_points() -> tuple[importlib.metadata.EntryPoint, ...]:
+def _get_entry_points() -> tuple[importlib.metadata.EntryPoint, ...]:
     """Get all Local Product Launcher plugin entry points for launchers."""
     try:
         return entry_points(group=LAUNCHER_ENTRY_POINT)  # type: ignore
     except KeyError:
         return tuple()
-
-
-def _get_product_instance_class_entry_points() -> tuple[importlib.metadata.EntryPoint, ...]:
-    """Get all Local Product Launcher plugin entry points for plugin instance classes."""
-    try:
-        return entry_points(group=PRODUCT_INSTANCE_CLASS_ENTRY_POINT)  # type: ignore
-    except KeyError:
-        return tuple()
-
-
-def get_product_instance_class(*, product_name: str, launch_mode: str) -> type[ProductInstance]:
-    """Get the product instance class for a given product and launch mode."""
-    res_cls = ProductInstance
-
-    for entrypoint in _get_product_instance_class_entry_points():
-        if entrypoint.name == f"{product_name}.{launch_mode}":
-            return entrypoint.load()  # type: ignore
-        elif entrypoint.name == product_name:
-            res_cls = entrypoint.load()
-    return res_cls

--- a/src/ansys/tools/local_product_launcher/launch.py
+++ b/src/ansys/tools/local_product_launcher/launch.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 
-from ._plugins import get_launcher, get_product_instance_class
+from ._plugins import get_launcher
 from .config import get_config_for, get_launch_mode_for
 from .interface import LAUNCHER_CONFIG_T, LauncherProtocol
 from .product_instance import ProductInstance
@@ -74,7 +74,4 @@ def launch_product(
             f"Incompatible config of type '{type(config)} supplied, "
             f"needs '{launcher_klass.CONFIG_MODEL}'."
         )
-    product_instance_cls = get_product_instance_class(
-        product_name=product_name, launch_mode=launch_mode
-    )
-    return product_instance_cls(launcher=launcher_klass(config=config))
+    return ProductInstance(launcher=launcher_klass(config=config))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def monkeypatch_entrypoints_from_plugins(monkeypatch):
     def inner(target_plugins):
         monkeypatch.setattr(
             _plugins,
-            "_get_launcher_entry_points",
+            "_get_entry_points",
             partial(get_mock_entrypoints_from_plugins, target_plugins=target_plugins),
         )
 

--- a/tests/test_cli/test_multiple_plugins.py
+++ b/tests/test_cli/test_multiple_plugins.py
@@ -78,7 +78,7 @@ def monkeypatch_entrypoints(monkeypatch_entrypoints_from_plugins):
 
 
 def test_cli_structure():
-    command = _cli.build_cli(_plugins.get_all_launcher_plugins())
+    command = _cli.build_cli(_plugins.get_all_plugins())
     assert "configure" in command.commands
     configure_group = command.commands["configure"]
 
@@ -96,7 +96,7 @@ def test_cli_structure():
 
 
 def test_configure_single_product_launcher(temp_config_file):
-    cli_command = _cli.build_cli(_plugins.get_all_launcher_plugins())
+    cli_command = _cli.build_cli(_plugins.get_all_plugins())
     runner = CliRunner()
     result = runner.invoke(
         cli_command,
@@ -116,7 +116,7 @@ def test_configure_single_product_launcher(temp_config_file):
 
 
 def test_configure_two_product_launchers(temp_config_file):
-    cli_command = _cli.build_cli(_plugins.get_all_launcher_plugins())
+    cli_command = _cli.build_cli(_plugins.get_all_plugins())
     runner = CliRunner()
     result = runner.invoke(
         cli_command,
@@ -144,7 +144,7 @@ def test_configure_two_product_launchers(temp_config_file):
 
 
 def test_configure_two_product_launchers_overwrite(temp_config_file):
-    cli_command = _cli.build_cli(_plugins.get_all_launcher_plugins())
+    cli_command = _cli.build_cli(_plugins.get_all_plugins())
     runner = CliRunner()
     result = runner.invoke(
         cli_command,
@@ -172,7 +172,7 @@ def test_configure_two_product_launchers_overwrite(temp_config_file):
 
 
 def test_configure_two_products(temp_config_file):
-    cli_command = _cli.build_cli(_plugins.get_all_launcher_plugins())
+    cli_command = _cli.build_cli(_plugins.get_all_plugins())
     runner = CliRunner()
     result = runner.invoke(
         cli_command,

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -21,14 +21,14 @@
 # SOFTWARE.
 
 from ansys.tools.local_product_launcher._plugins import (
-    get_all_launcher_plugins,
+    get_all_plugins,
     get_config_model,
     get_launcher,
 )
 
 
 def test_plugin_found():
-    plugin_dict = get_all_launcher_plugins()
+    plugin_dict = get_all_plugins()
     assert "pkg_with_entrypoint" in plugin_dict
     assert "test_entry_point" in plugin_dict["pkg_with_entrypoint"]
 

--- a/tests/test_plugins/test_plugins.py
+++ b/tests/test_plugins/test_plugins.py
@@ -77,7 +77,7 @@ def monkeypatch_entrypoints(monkeypatch_entrypoints_from_plugins):
 
 
 def test_get_all_plugins(monkeypatch_entrypoints):
-    assert _plugins.get_all_launcher_plugins() == PLUGINS
+    assert _plugins.get_all_plugins() == PLUGINS
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Remove the ability to specify a custom product instance subclass via an entrypoint. Libraries using the launcher in this way are encouraged to extend the product instance via composition instead.