### PR TITLE
Increase the gRPC receive message limit to 256 MB

### DIFF
--- a/src/ansys/tools/local_product_launcher/product_instance.py
+++ b/src/ansys/tools/local_product_launcher/product_instance.py
@@ -34,6 +34,8 @@ from .interface import LAUNCHER_CONFIG_T, LauncherProtocol, ServerType
 
 __all__ = ["ProductInstance"]
 
+_GRPC_MAX_MESSAGE_LENGTH = 256 * 1024**2  # 256 MB
+
 
 class ProductInstance:
     """Wrapper to interact with the launched product instance.
@@ -87,7 +89,10 @@ class ProductInstance:
             )
         for key, server_type in self._launcher.SERVER_SPEC.items():
             if server_type == ServerType.GRPC:
-                self._channels[key] = grpc.insecure_channel(urls[key])
+                self._channels[key] = grpc.insecure_channel(
+                    urls[key],
+                    options=[("grpc.max_receive_message_length", _GRPC_MAX_MESSAGE_LENGTH)],
+                )
 
     def stop(self, *, timeout: float | None = None) -> None:
         """Stop the product instance.


### PR DESCRIPTION
Increase the default grpc message size limit to 256 MB.

This is a stop-gap measure before ansys/ansys-tools-common#145 can be implemented.