### PR TITLE
Use launch mode defaults when available if not configured

### DIFF
--- a/src/ansys/tools/local_product_launcher/_cli.py
+++ b/src/ansys/tools/local_product_launcher/_cli.py
@@ -249,11 +249,16 @@ def build_cli(plugins: dict[str, dict[str, LauncherProtocol[LAUNCHER_CONFIG_T]]]
                     else:
                         click.echo(f"    {launch_mode}")
 
-                    try:
-                        config = get_config_for(product_name=product_name, launch_mode=launch_mode)
-                    except KeyError:
-                        click.echo("        No configuration is set.")
-                        continue
+                    if not is_configured(product_name=product_name, launch_mode=launch_mode):
+                        try:
+                            config = get_config_for(
+                                product_name=product_name, launch_mode=launch_mode
+                            )
+                            click.echo("        No configuration is set (uses defaults).")
+                        except KeyError:
+                            click.echo("        No configuration is set (no defaults available).")
+                            continue
+                    config = get_config_for(product_name=product_name, launch_mode=launch_mode)
                     for field in dataclasses.fields(config):
                         click.echo(f"        {field.name}: {getattr(config, field.name)}")
             except KeyError:

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -56,3 +56,8 @@ def test_get_config_model():
         product_name="pkg_with_entrypoint", launch_mode="test_entry_point"
     )
     assert config_model.__name__ == "LauncherConfig"
+
+
+def test_get_config_for_default():
+    """Test that get_config_for returns the default configuration when given a launch_mode."""
+    get_config_for(product_name="pkg_with_entrypoint", launch_mode="test_entry_point")


### PR DESCRIPTION
When a `launch_mode` is explicitly requested which is not configured,
use its default configuration if available.

Closes #148 